### PR TITLE
Fix panic on `getFieldByIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - (2018-06-27) Fix struct codec, func `Select` and func `DistinctOn`
 - (2018-06-28) Fix `Postgres` update with limit clause bug. Only mysql support `UPDATE xxx SET xxx LIMIT 10`. Postgres instead will use `UPDATE xxx SET xxx WHERE key IN (SELECT xxx FROM xxx LIMIT 10)`.
 - (2018-06-28) Fix `Paginate` bug, invalid cursor signature due to `qson` package didn't sort the filter fields
+- (2018-07-01) Fix `panic: reflect: Field index out of range` on embeded struct, code paths is invalid
 
 # Breaking Changes
 

--- a/struct_codec.go
+++ b/struct_codec.go
@@ -272,7 +272,7 @@ func getStructCodec(it interface{}) (*StructCodec, error) {
 				}
 
 				sc := newStructCodec(reflect.New(ft))
-				f := newField(st, first.field, []int{i}, seq, sf.Type, first.isPtrChild, sc)
+				f := newField(st, first.field, append(first.path, i), seq, sf.Type, first.isPtrChild, sc)
 				fields = append(fields, f)
 				sc.parentField = &f
 				// reset the position when it's another struct


### PR DESCRIPTION
Fix panic on `getFieldByIndex`, struct codec contain invalid index path for embedded struct properties