### PR TITLE
change match againt value to accept array

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -250,7 +250,6 @@ func (b *builder) buildWhere(query scope) (*stmt, error) {
 			} else {
 				wheres = append(wheres, fmt.Sprintf("MATCH(%s) AGAINST(%s)", name, variable))
 			}
-			args = append(args, v)
 			continue
 		}
 		wheres = append(wheres, fmt.Sprintf("%s %s %s", name, op, vv))

--- a/db.go
+++ b/db.go
@@ -374,7 +374,7 @@ func (db *DB) Where(field string, operator string, value interface{}) *Query {
 }
 
 // Where :
-func (db *DB) MatchAgainst(fields []string, value string) *Query {
+func (db *DB) MatchAgainst(fields []string, value []string) *Query {
 	return db.NewQuery().MatchAgainst(fields, value)
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -167,7 +167,7 @@ func WhereJSON(field string, operator string, value interface{}) *goloquent.Quer
 }
 
 // MatchAgainst :
-func MatchAgainst(fields []string, value string) *goloquent.Query {
+func MatchAgainst(fields []string, value []string) *goloquent.Query {
 	return defaultDB.NewQuery().MatchAgainst(fields, value)
 }
 

--- a/query.go
+++ b/query.go
@@ -480,7 +480,7 @@ func (q *Query) WhereJSONIsArray(field string) *Query {
 }
 
 // MatchAgainst :
-func (q *Query) MatchAgainst(fields []string, v string) *Query {
+func (q *Query) MatchAgainst(fields []string, v []string) *Query {
 	f := Filter{}
 	f.operator = MatchAgainst
 	f.raw = "MATCH("
@@ -490,8 +490,11 @@ func (q *Query) MatchAgainst(fields []string, v string) *Query {
 		}
 		f.raw += "`" + field + "`"
 	}
-	f.raw += ") AGAINST(" + variable + ")"
-	f.value = v
+	f.raw += ") AGAINST('"
+	for _, value := range v {
+		f.raw += "\"" + value + "\" "
+	}
+	f.raw += "')"
 	q.filters = append(q.filters, f)
 	return q
 }


### PR DESCRIPTION
1) Change the MatchAgainst API to accept an array of values instead of raw text. 
2) Fix the quoting of values, to escape MySQL parser built-in symbol
change from AGAINST ("value1  value2") to AGAINST(' "value1" "value2" ')
